### PR TITLE
feat: port upstream PR#779 (debug host + stable Chrome shutdown)

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -1,5 +1,5 @@
 const CDP = require('chrome-remote-interface');
-const { spawn } = require('child_process');
+const { spawn } = require('node:child_process');
 const util = require('../util.js');
 const fs = require('fs');
 const os = require('os');
@@ -24,7 +24,8 @@ const PrintPdfTimedOut = 'PrintPdfTimedOut';
 const UnableToCapturePdf = 'UnableToCapturePdf';
 
 chrome.name = 'Chrome';
-const host = '127.0.0.1';
+// default host if not provided via options
+const defaultHost = '127.0.0.1';
 
 chrome.spawn = function (options) {
   return new Promise((resolve, reject) => {
@@ -53,10 +54,11 @@ chrome.spawn = function (options) {
     }
 
     if (os.platform() === 'darwin') {
-      this.chromeChild = spawn(location, chromeFlags, { shell: false });
+      this.chromeChild = spawn(location, chromeFlags, { shell: false, detached: true });
     } else {
-      this.chromeChild = spawn(location, chromeFlags, { shell: true });
+      this.chromeChild = spawn(location, chromeFlags, { shell: true, detached: true });
     }
+    // detached will group all the processes so we can kill them easily later
 
     resolve();
   });
@@ -68,7 +70,13 @@ chrome.onClose = function (callback) {
 
 chrome.kill = function () {
   if (this.chromeChild) {
-    this.chromeChild.kill('SIGINT');
+    const signal = 'SIGINT';
+    util.log(`Sending ${signal} to browser PID group ${this.chromeChild.pid}`);
+    try {
+      process.kill(-this.chromeChild.pid, signal); // negative PID kills the entire group
+    } catch (err) {
+      util.log('Error killing Chrome process group', err);
+    }
   }
 };
 
@@ -82,14 +90,14 @@ chrome.connect = function () {
     }, 20 * 1000);
 
     let connect = () => {
+      const host = this.options.browserDebuggingHost || defaultHost;
       CDP.Version({ host, port: this.options.browserDebuggingPort })
         .then((info) => {
           this.originalUserAgent = info['User-Agent'];
           this.webSocketDebuggerURL =
             info.webSocketDebuggerUrl ||
-            'ws://localhost:' +
-              this.options.browserDebuggingPort +
-              '/devtools/browser';
+            `ws://${host}:${this.options.browserDebuggingPort}/devtools/browser`;
+          util.log(`Got webSocketDebuggerURL: ${this.webSocketDebuggerURL}`);
           this.version = info.Browser;
 
           clearTimeout(timeout);
@@ -97,7 +105,7 @@ chrome.connect = function () {
           resolve();
         })
         .catch((err) => {
-          util.log('retrying connection to Chrome...');
+          util.log('Error while running CDP.Version (will retry)', err);
           return setTimeout(connect, 1000);
         });
     };
@@ -130,15 +138,14 @@ chrome.openTab = function (options) {
   return new Promise((resolve, reject) => {
     let browserContext = null;
     let browser = null;
-
-    const connectToBrowser = async (target, port) => {
+    const connectToBrowser = async (host, port, target) => {
       let remainingRetries = 5;
       for (;;) {
         try {
-          return await CDP({ host, target, port });
+          return await CDP({ host, port, target });
         } catch (err) {
           util.log(
-            `Cannot connect to browser port=${port} remainingRetries=${remainingRetries}`,
+            `Cannot connect to browser host=${host}, port=${port}, target=${target}, remainingRetries=${remainingRetries}`,
             err,
           );
           if (remainingRetries <= 0) {
@@ -150,11 +157,8 @@ chrome.openTab = function (options) {
         }
       }
     };
-
-    connectToBrowser(
-      this.webSocketDebuggerURL,
-      this.options.browserDebuggingPort,
-    )
+    const host = this.options.browserDebuggingHost || defaultHost;
+    connectToBrowser(host, this.options.browserDebuggingPort, this.webSocketDebuggerURL)
       .then((chromeBrowser) => {
         browser = chromeBrowser;
 
@@ -169,7 +173,7 @@ chrome.openTab = function (options) {
         });
       })
       .then(({ targetId }) => {
-        return connectToBrowser(targetId, this.options.browserDebuggingPort);
+        return connectToBrowser(host, this.options.browserDebuggingPort, targetId);
       })
       .then((tab) => {
         //we're going to put our state on the chrome tab for now
@@ -187,6 +191,7 @@ chrome.openTab = function (options) {
         resolve(tab);
       })
       .catch((err) => {
+        util.log('Error on connectToBrowser (openTab) pipeline', err);
         reject(err);
       });
   });

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,6 +20,8 @@ const ENABLE_SERVICE_WORKER = process.env.ENABLE_SERVICE_WORKER || false;
 const BROWSER_TRY_RESTART_PERIOD =
   process.env.BROWSER_TRY_RESTART_PERIOD || 600000;
 
+const BROWSER_DEBUGGING_HOST =
+  process.env.BROWSER_DEBUGGING_HOST || '127.0.0.1';
 const BROWSER_DEBUGGING_PORT = process.env.BROWSER_DEBUGGING_PORT || 9222;
 
 const TIMEOUT_STATUS_CODE = process.env.TIMEOUT_STATUS_CODE;
@@ -48,6 +50,8 @@ server.init = function (options) {
   this.options.pdfOptions = this.options.pdfOptions || {
     printBackground: true,
   };
+  this.options.browserDebuggingHost =
+    this.options.browserDebuggingHost || BROWSER_DEBUGGING_HOST;
   this.options.browserDebuggingPort =
     this.options.browserDebuggingPort || BROWSER_DEBUGGING_PORT;
   this.options.timeoutStatusCode =
@@ -153,6 +157,7 @@ server.listenForBrowserClose = function () {
   this.isBrowserClosing = false;
 
   this.browser.onClose(() => {
+    util.log('Starting browser shutdown pipeline');
     this.isBrowserConnected = false;
     if (this.isBrowserClosing) {
       util.log(`Stopped ${this.browser.name}`);


### PR DESCRIPTION
Port of upstream prerender/prerender#779

Key changes:

- Added BROWSER_DEBUGGING_HOST env/option (defaults 127.0.0.1)
- CDP connections now use configured host everywhere
- Log WebSocket debugger URL when obtained
- Chrome spawned in its own process group (detached) for cleaner shutdown
- Kill entire Chrome process group via negative PID (prevents orphan processes)
- Improved retry/error logging for CDP.Version and tab connection
- Added shutdown pipeline log for easier diagnostics

Motivation: We were experiencing persistent 504s likely caused by flaky Chrome connections and lingering orphaned Chrome processes. These changes improve observability and lifecycle management.

No behavior change expected for existing setups unless they rely on non-local debug hosts; set BROWSER_DEBUGGING_HOST explicitly if needed.